### PR TITLE
👷 add workflow to deploy redoc docs to gh-pages

### DIFF
--- a/.github/workflows/deploy-redoc-docs.yml
+++ b/.github/workflows/deploy-redoc-docs.yml
@@ -1,0 +1,43 @@
+name: Deploy Redocly API Documentation To GitHub Pages
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  build:
+    name: Build Static Redocly API Documentation HTML
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: lts/*
+
+      - name: Install Redocly CLI
+        run: npm install -g @redocly/cli
+
+      - name: Build Redocly API Documentation
+        run: redocly build-docs docs/openapi.yml --output _site/index.html
+
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v2
+
+  deploy:
+    name: Deploy to GitHub Pages
+    runs-on: ubuntu-latest
+    needs: build
+    permissions:
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v2


### PR DESCRIPTION
## 📝 Summary

- added a GitHub workflow to deploy Redocly documentation to gh-pages when `main` branch changes
