### PR TITLE
feat: endpoint schemas for accesssing websites

### DIFF
--- a/app/app.py
+++ b/app/app.py
@@ -3,7 +3,7 @@ from fastapi import FastAPI
 from pydantic import BaseModel
 from starlette.middleware.base import BaseHTTPMiddleware
 
-from app import logger
+from app import logger, websites
 from app.core import settings
 
 logger.setup_logging(
@@ -30,8 +30,11 @@ class PingResponse(BaseModel):
     message: str = "Server is up and running 🚀"
 
 
-@app.get("/")
+@app.get("/", tags=["ping"])
 async def ping() -> PingResponse:
     """Ping the API to check if it's alive."""
 
     return PingResponse()
+
+
+app.include_router(websites.router)

--- a/app/websites/__init__.py
+++ b/app/websites/__init__.py
@@ -1,0 +1,3 @@
+from .routes import router
+
+__all__ = ["router"]

--- a/app/websites/routes.py
+++ b/app/websites/routes.py
@@ -37,11 +37,10 @@ async def update_website(
 
 
 @router.get(
-    "/{website_id}/search",
+    "/search",
     responses={400: {"description": "Invalid parameters"}},
 )
 async def search(
-    website_id: str,
     q: str = "",
     cursor: str = "",
     limit: Annotated[int, Query(ge=1, le=50)] = 10,

--- a/app/websites/routes.py
+++ b/app/websites/routes.py
@@ -5,6 +5,7 @@ from fastapi import APIRouter, Query
 from pydantic_core import Url
 
 from app.websites.schemas import (
+    Affiliation,
     Pagination,
     SearchResponse,
     UpdateResponse,
@@ -28,9 +29,13 @@ async def update_website(
 ) -> UpdateResponse:
     return UpdateResponse(
         id="clrnc14dr000008l235gx4c6c",
-        campus="交大相關",
-        department="行政單位",
-        office="圖書館",
+        affiliations=[
+            Affiliation(
+                campus="交大相關",
+                department="行政單位",
+                office="圖書館",
+            )
+        ],
         name="交通大學圖書館",
         url=Url("https://www.lib.nctu.edu.tw/"),
     )
@@ -49,7 +54,6 @@ async def search(
         result=[],
         pagination=Pagination(
             next_cursor="",
-            has_next=False,
             num_results=0,
             total_results=0,
         ),

--- a/app/websites/routes.py
+++ b/app/websites/routes.py
@@ -1,0 +1,57 @@
+from datetime import date
+from typing import Annotated
+
+from fastapi import APIRouter, Query
+from pydantic_core import Url
+
+from app.websites.schemas import (
+    Pagination,
+    SearchResponse,
+    UpdateResponse,
+    UpdateWebsitePayload,
+)
+
+router = APIRouter(
+    prefix="/api/website",
+    tags=["websites"],
+)
+
+
+@router.get("/{website_id}")
+async def get_archived_dates(website_id: str) -> list[date]:
+    return []
+
+
+@router.patch("/{website_id}")
+async def update_website(
+    website_id: str, payload: UpdateWebsitePayload
+) -> UpdateResponse:
+    return UpdateResponse(
+        id="clrnc14dr000008l235gx4c6c",
+        campus="交大相關",
+        department="行政單位",
+        office="圖書館",
+        name="交通大學圖書館",
+        url=Url("https://www.lib.nctu.edu.tw/"),
+    )
+
+
+@router.get(
+    "/{website_id}/search",
+    responses={400: {"description": "Invalid parameters"}},
+)
+async def search(
+    website_id: str,
+    q: str = "",
+    cursor: str = "",
+    limit: Annotated[int, Query(ge=1, le=50)] = 10,
+) -> SearchResponse:
+    return SearchResponse(
+        result=[],
+        pagination=Pagination(
+            next_cursor="",
+            has_next=False,
+            num_results=0,
+            total_results=0,
+        ),
+    )

--- a/app/websites/schemas.py
+++ b/app/websites/schemas.py
@@ -1,0 +1,111 @@
+from typing import Optional
+
+from pydantic import AnyUrl, BaseModel, ConfigDict, Field
+
+
+class Affiliation(BaseModel):
+    campus: str = Field(..., description="Campus name")
+    department: str = Field(..., description="Department name")
+    office: str = Field(..., description="Office name")
+
+
+class UpdateWebsitePayload(BaseModel):
+    affiliations: list[Affiliation] = Field(
+        [], description="The affiliations of the website"
+    )
+    name: Optional[str] = Field(None, description="The name of the website")
+    url: Optional[AnyUrl] = Field(None, description="The URL of the website")
+
+    model_config: ConfigDict = {
+        "json_schema_extra": {
+            "example": {
+                "affiliations": [
+                    {
+                        "campus": "交大相關",
+                        "department": "行政單位",
+                        "office": "圖書館",
+                    }
+                ],
+                "name": "交通大學圖書館",
+                "url": "https://www.lib.nctu.edu.tw/",
+            }
+        }
+    }
+
+
+class UpdateResponse(BaseModel):
+    id: str = Field(..., description="The ID of the website")
+    campus: str = Field(..., description="Campus name")
+    department: str = Field(..., description="Department name")
+    office: str = Field(..., description="Office name")
+    name: str = Field(..., description="The name of the website")
+    url: AnyUrl = Field(..., description="The URL of the website")
+
+    model_config: ConfigDict = {
+        "json_schema_extra": {
+            "example": {
+                "id": "clrnc14dr000008l235gx4c6c",
+                "campus": "交大相關",
+                "department": "行政單位",
+                "office": "圖書館",
+                "name": "交通大學圖書館",
+                "url": "https://www.lib.nctu.edu.tw/",
+            }
+        }
+    }
+
+
+class SearchResultWebsite(BaseModel):
+    id: str = Field(..., description="The ID of the website")
+    name: str = Field(..., description="The name of the website")
+    url: AnyUrl = Field(..., description="The URL of the website")
+
+
+class SearchResultEntry(BaseModel):
+    id: str = Field(..., description="Compound ID of the website")
+    campus: str = Field(..., description="Campus name")
+    department: str = Field(..., description="Department name")
+    office: str = Field(..., description="Office name")
+    websites: list[SearchResultWebsite] = Field(
+        ..., description="The websites that match the query"
+    )
+
+
+class Pagination(BaseModel):
+    next_cursor: str = Field(..., description="Cursor for the next page")
+    has_next: bool = Field(..., description="Whether there is a next page")
+    num_results: int = Field(..., description="Number of results in this page")
+    total_results: int = Field(..., description="Total number of results")
+
+
+class SearchResponse(BaseModel):
+    result: list[SearchResultEntry] = Field(..., description="The search result")
+    pagination: Pagination = Field(..., description="Pagination information")
+
+    model_config: ConfigDict = {
+        "json_schema_extra": {
+            "example": {
+                "result": [
+                    {
+                        "id": "clrnc1mt7000108l21whi9y4r$clrnc1tdu000208l2dm2hcimi$clrnc1wx0000308l2h9st7aac",
+                        "campus": "交大相關",
+                        "department": "行政單位",
+                        "office": "圖書館",
+                        "websites": [
+                            {
+                                "id": "clrnc14dr000008l235gx4c6c",
+                                "name": "交通大學圖書館",
+                                "url": "https://www.lib.nctu.edu.tw/",
+                            }
+                        ],
+                    }
+                ],
+                "pagination": {
+                    "next_cursor": "KGNhbXB1c19pZD1jbHJuYzFtdDcwMDAxMDhsMjF3aGk5eTRyLGRlcGFydG1lbnRfaWQ9Y2xybmMxdGR1MDAwMjA4bDJkbTJoY2ltaSxvZmZpY2VfaWQ9Y2xybmMxd3gwMDAwMzA4bDJoOXN0N2FhYyx3ZWJzaXRlX2lkPWNscm5jMTRkcjAwMDAwOGwyMzVneDRjNmMp",
+                    "has_next": True,
+                    "num_results": 1,
+                    "total_results": 10,
+                },
+            }
+        }
+    }

--- a/app/websites/schemas.py
+++ b/app/websites/schemas.py
@@ -35,21 +35,25 @@ class UpdateWebsitePayload(BaseModel):
 
 class UpdateResponse(BaseModel):
     id: str = Field(..., description="The ID of the website")
-    campus: str = Field(..., description="Campus name")
-    department: str = Field(..., description="Department name")
-    office: str = Field(..., description="Office name")
     name: str = Field(..., description="The name of the website")
     url: AnyUrl = Field(..., description="The URL of the website")
+    affiliations: list[Affiliation] = Field(
+        ..., description="The affiliations of the website"
+    )
 
     model_config: ConfigDict = {
         "json_schema_extra": {
             "example": {
                 "id": "clrnc14dr000008l235gx4c6c",
-                "campus": "交大相關",
-                "department": "行政單位",
-                "office": "圖書館",
                 "name": "交通大學圖書館",
                 "url": "https://www.lib.nctu.edu.tw/",
+                "affiliations": [
+                    {
+                        "campus": "交大相關",
+                        "department": "行政單位",
+                        "office": "圖書館",
+                    }
+                ],
             }
         }
     }

--- a/app/websites/schemas.py
+++ b/app/websites/schemas.py
@@ -73,7 +73,6 @@ class SearchResultEntry(BaseModel):
 
 class Pagination(BaseModel):
     next_cursor: str = Field(..., description="Cursor for the next page")
-    has_next: bool = Field(..., description="Whether there is a next page")
     num_results: int = Field(..., description="Number of results in this page")
     total_results: int = Field(..., description="Total number of results")
 
@@ -102,7 +101,6 @@ class SearchResponse(BaseModel):
                 ],
                 "pagination": {
                     "next_cursor": "KGNhbXB1c19pZD1jbHJuYzFtdDcwMDAxMDhsMjF3aGk5eTRyLGRlcGFydG1lbnRfaWQ9Y2xybmMxdGR1MDAwMjA4bDJkbTJoY2ltaSxvZmZpY2VfaWQ9Y2xybmMxd3gwMDAwMzA4bDJoOXN0N2FhYyx3ZWJzaXRlX2lkPWNscm5jMTRkcjAwMDAwOGwyMzVneDRjNmMp",
-                    "has_next": True,
                     "num_results": 1,
                     "total_results": 10,
                 },


### PR DESCRIPTION


---

<details open="true"><summary>Generated summary (powered by <a href="https://app.graphite.dev">Graphite</a>)</summary>

> ## TL;DR
> This pull request adds a new feature to the application by introducing a new module called `websites`. It includes new routes for retrieving archived dates, updating websites, and searching for websites. It also includes new schemas for payloads and responses related to websites.
> 
> ## What changed
> - Added `websites` module with routes and schemas
> - Modified `app.py` to import the `websites` module and include its router
> - Added new routes for retrieving archived dates, updating websites, and searching for websites
> - Added new schemas for payloads and responses related to websites
> 
> ## How to test
> 1. Run the application
> 2. Access the new routes:
>    - `/api/website/{website_id}`: Retrieve archived dates for a website
>    - `/api/website/{website_id}`: Update a website
>    - `/api/website/{website_id}/search`: Search for websites
> 3. Verify that the routes return the expected responses
> 
> ## Why make this change
> This change was made to add functionality related to managing websites in the application. The new routes allow users to retrieve archived dates for a website, update a website's information, and search for websites based on certain criteria. This enhances the overall capabilities of the application and provides more flexibility for users.
</details>