### PR TITLE
fix: seed database command

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,5 +21,5 @@ docker compose up
 5. If your volume is empty, you need to seed the database 
 
 ```bash
-docker compose exec -T db psql -U ${DB_USER:-app} < /path/to/dump-file.sql
+docker compose exec -T db psql -U ${DB_USER:-app} ${DB_NAME:-db} < /path/to/dump-file.sql
 ```


### PR DESCRIPTION




This pull request updates the command in the README.md file for seeding the database in a Docker environment. The updated command now includes the database name.
