### PR TITLE
feat: dump openapi script

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: CI
 
 on:
   push:
-    branches: [main]
+    branches: [main, 01-28-dump_openapi]
   pull_request:
   workflow_dispatch:
 
@@ -44,3 +44,16 @@ jobs:
         uses: jakebailey/pyright-action@v2
         with:
           pylance-version: latest-release
+
+  openapi:
+    name: Generate OpenAPI schema
+    runs-on: ubuntu-latest
+    steps:
+      - name: Setup repo
+        uses: ./.github/workflows/setup-repo.yml
+        with:
+          dev-dependencies: true
+          build-command: "pdm run schema:gen diff.json"
+
+      - name: Check OpenAPI schema
+        run: diff openapi.json diff.json

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: CI
 
 on:
   push:
-    branches: [01-28-dump_openapi]
+    branches: [main]
   pull_request:
   workflow_dispatch:
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: CI
 
 on:
   push:
-    branches: [main, 01-28-dump_openapi]
+    branches: [01-28-dump_openapi]
   pull_request:
   workflow_dispatch:
 
@@ -55,5 +55,5 @@ jobs:
           dev-dependencies: true
           build-command: "pdm run schema:gen diff.json"
 
-      - name: Check OpenAPI schema
-        run: diff openapi.json diff.json
+      # - name: Check OpenAPI schema
+      #   run: diff openapi.json diff.json

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,7 +65,7 @@ jobs:
         run: dirname $(pdm info --python) >> $GITHUB_PATH
 
       - name: Dump OpenAPI schema
-        run: pdm run schema:gen diff.json
+        run: pdm run schema:gen --dump-path diff.json
 
       - name: Check OpenAPI schema
         run: diff openapi.json diff.json

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,14 +46,26 @@ jobs:
           pylance-version: latest-release
 
   openapi:
-    name: Generate OpenAPI schema
+    name: Check OpenAPI schema
     runs-on: ubuntu-latest
     steps:
-      - name: Setup repo
-        uses: ./.github/workflows/setup-repo.yml
-        with:
-          dev-dependencies: true
-          build-command: "pdm run schema:gen diff.json"
+      - name: Checkout Repository
+        uses: actions/checkout@v4
 
-      # - name: Check OpenAPI schema
-      #   run: diff openapi.json diff.json
+      - name: Setup PDM
+        uses: pdm-project/setup-pdm@v3
+        with:
+          python-version: "3.12"
+          cache: true
+
+      - name: Install Dependencies
+        run: pdm install --frozen-lockfile
+
+      - name: Add python to PATH
+        run: dirname $(pdm info --python) >> $GITHUB_PATH
+
+      - name: Dump OpenAPI schema
+        run: pdm run schema:gen diff.json
+
+      - name: Check OpenAPI schema
+        run: diff openapi.json diff.json

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,6 +64,9 @@ jobs:
       - name: Add python to PATH
         run: dirname $(pdm info --python) >> $GITHUB_PATH
 
+      - name: Fabricate environment
+        run: cp .env.example .env
+
       - name: Dump OpenAPI schema
         run: pdm run schema:gen --dump-path diff.json
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,6 @@
 ### sql ###
 *.sql
 
-### Schema ###
-openapi.json
-
 # Created by https://www.toptal.com/developers/gitignore/api/python,linux,macos,windows,visualstudiocode
 # Edit at https://www.toptal.com/developers/gitignore?templates=python,linux,macos,windows,visualstudiocode
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,9 @@
+### sql ###
+*.sql
+
+### Schema ###
+openapi.json
+
 # Created by https://www.toptal.com/developers/gitignore/api/python,linux,macos,windows,visualstudiocode
 # Edit at https://www.toptal.com/developers/gitignore?templates=python,linux,macos,windows,visualstudiocode
 
@@ -24,7 +30,6 @@
 
 # Icon must end with two \r
 Icon
-
 
 # Thumbnails
 ._*

--- a/app/openapi.py
+++ b/app/openapi.py
@@ -1,0 +1,16 @@
+import json
+from pathlib import Path
+
+from app.app import app
+
+
+def main():
+    dump_path = Path(__file__).parent.parent / "openapi.json"
+    schema = app.openapi()
+
+    with open(dump_path, "w") as schema_file:
+        json.dump(schema, schema_file, indent=2)
+
+
+if __name__ == "__main__":
+    main()

--- a/app/openapi.py
+++ b/app/openapi.py
@@ -6,7 +6,13 @@ from app.app import app
 
 
 @click.command(name="dump-schema", help="Dump OpenAPI schema to a file")
-@click.option("--dump-path", "-D", type=click.Path(), default="openapi.json", help="Path to dump OpenAPI schema")
+@click.option(
+    "--dump-path",
+    "-D",
+    type=click.Path(),
+    default="openapi.json",
+    help="Path to dump OpenAPI schema",
+)
 def dump_schema(dump_path: str):
     schema = app.openapi()
 

--- a/app/openapi.py
+++ b/app/openapi.py
@@ -1,11 +1,13 @@
 import json
-from pathlib import Path
+
+import click
 
 from app.app import app
 
 
-def main():
-    dump_path = Path(__file__).parent.parent / "openapi.json"
+@click.command(name="dump-schema", help="Dump OpenAPI schema to a file")
+@click.option("--dump-path", "-D", type=click.Path(), default="openapi.json", help="Path to dump OpenAPI schema")
+def dump_schema(dump_path: str):
     schema = app.openapi()
 
     with open(dump_path, "w") as schema_file:
@@ -13,4 +15,4 @@ def main():
 
 
 if __name__ == "__main__":
-    main()
+    dump_schema()

--- a/openapi.json
+++ b/openapi.json
@@ -1,0 +1,564 @@
+{
+  "openapi": "3.1.0",
+  "info": {
+    "title": "Archive API",
+    "description": "API for the WebArchive project",
+    "version": "0.1.0"
+  },
+  "paths": {
+    "/": {
+      "get": {
+        "tags": [
+          "ping"
+        ],
+        "summary": "Ping",
+        "description": "Ping the API to check if it's alive.",
+        "operationId": "ping__get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PingResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/website/{website_id}": {
+      "patch": {
+        "tags": [
+          "websites"
+        ],
+        "summary": "Update Website",
+        "operationId": "update_website_api_website__website_id__patch",
+        "parameters": [
+          {
+            "name": "website_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Website Id"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UpdateWebsitePayload"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/UpdateResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "get": {
+        "tags": [
+          "websites"
+        ],
+        "summary": "Get Archived Dates",
+        "operationId": "get_archived_dates_api_website__website_id__get",
+        "parameters": [
+          {
+            "name": "website_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Website Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "type": "string",
+                    "format": "date"
+                  },
+                  "title": "Response Get Archived Dates Api Website  Website Id  Get"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/website/search": {
+      "get": {
+        "tags": [
+          "websites"
+        ],
+        "summary": "Search Websites",
+        "operationId": "search_websites_api_website_search_get",
+        "parameters": [
+          {
+            "name": "q",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Q"
+            }
+          },
+          {
+            "name": "cursor",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Cursor for pagination (in base64)",
+              "title": "Cursor"
+            },
+            "description": "Cursor for pagination (in base64)"
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "maximum": 50,
+              "minimum": 1,
+              "default": 10,
+              "title": "Limit"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SearchResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid parameters",
+            "content": {
+              "application/json": {
+                "example": {
+                  "detail": [
+                    {
+                      "loc": [
+                        "query",
+                        "cursor"
+                      ],
+                      "msg": "invalid key-value pair format",
+                      "type": "invalid_cursor_format"
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "Affiliation": {
+        "properties": {
+          "campus": {
+            "type": "string",
+            "title": "Campus",
+            "description": "Campus name"
+          },
+          "department": {
+            "type": "string",
+            "title": "Department",
+            "description": "Department name"
+          },
+          "office": {
+            "type": "string",
+            "title": "Office",
+            "description": "Office name"
+          }
+        },
+        "type": "object",
+        "required": [
+          "campus",
+          "department",
+          "office"
+        ],
+        "title": "Affiliation"
+      },
+      "HTTPValidationError": {
+        "properties": {
+          "detail": {
+            "items": {
+              "$ref": "#/components/schemas/ValidationError"
+            },
+            "type": "array",
+            "title": "Detail"
+          }
+        },
+        "type": "object",
+        "title": "HTTPValidationError"
+      },
+      "Pagination": {
+        "properties": {
+          "next_cursor": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Next Cursor",
+            "description": "Cursor for the next page"
+          },
+          "num_results": {
+            "type": "integer",
+            "title": "Num Results",
+            "description": "Number of results in this page"
+          },
+          "num_left": {
+            "type": "integer",
+            "title": "Num Left",
+            "description": "Number of results left"
+          }
+        },
+        "type": "object",
+        "required": [
+          "num_results",
+          "num_left"
+        ],
+        "title": "Pagination"
+      },
+      "PingResponse": {
+        "properties": {
+          "message": {
+            "type": "string",
+            "title": "Message",
+            "default": "Server is up and running \ud83d\ude80"
+          }
+        },
+        "type": "object",
+        "title": "PingResponse"
+      },
+      "SearchResponse": {
+        "properties": {
+          "result": {
+            "items": {
+              "$ref": "#/components/schemas/SearchResultEntry"
+            },
+            "type": "array",
+            "title": "Result",
+            "description": "The search result"
+          },
+          "pagination": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/Pagination"
+              }
+            ],
+            "description": "Pagination information"
+          }
+        },
+        "type": "object",
+        "required": [
+          "result",
+          "pagination"
+        ],
+        "title": "SearchResponse",
+        "example": {
+          "pagination": {
+            "next_cursor": "KGNhbXB1c19pZD1jbHJuYzFtdDcwMDAxMDhsMjF3aGk5eTRyLGRlcGFydG1lbnRfaWQ9Y2xybmMxdGR1MDAwMjA4bDJkbTJoY2ltaSxvZmZpY2VfaWQ9Y2xybmMxd3gwMDAwMzA4bDJoOXN0N2FhYyx3ZWJzaXRlX2lkPWNscm5jMTRkcjAwMDAwOGwyMzVneDRjNmMp",
+            "num_results": 1,
+            "total_results": 10
+          },
+          "result": [
+            {
+              "campus": "\u4ea4\u5927\u76f8\u95dc",
+              "department": "\u884c\u653f\u55ae\u4f4d",
+              "id": "clrnc1mt7000108l21whi9y4r$clrnc1tdu000208l2dm2hcimi$clrnc1wx0000308l2h9st7aac",
+              "office": "\u5716\u66f8\u9928",
+              "websites": [
+                {
+                  "id": "clrnc14dr000008l235gx4c6c",
+                  "name": "\u4ea4\u901a\u5927\u5b78\u5716\u66f8\u9928",
+                  "url": "https://www.lib.nctu.edu.tw/"
+                }
+              ]
+            }
+          ]
+        }
+      },
+      "SearchResultEntry": {
+        "properties": {
+          "id": {
+            "type": "string",
+            "title": "Id",
+            "description": "Compound ID of the website"
+          },
+          "campus": {
+            "type": "string",
+            "title": "Campus",
+            "description": "Campus name"
+          },
+          "department": {
+            "type": "string",
+            "title": "Department",
+            "description": "Department name"
+          },
+          "office": {
+            "type": "string",
+            "title": "Office",
+            "description": "Office name"
+          },
+          "websites": {
+            "items": {
+              "$ref": "#/components/schemas/SearchResultWebsite"
+            },
+            "type": "array",
+            "title": "Websites",
+            "description": "The websites that match the query"
+          }
+        },
+        "type": "object",
+        "required": [
+          "id",
+          "campus",
+          "department",
+          "office",
+          "websites"
+        ],
+        "title": "SearchResultEntry"
+      },
+      "SearchResultWebsite": {
+        "properties": {
+          "id": {
+            "type": "string",
+            "title": "Id",
+            "description": "The ID of the website"
+          },
+          "name": {
+            "type": "string",
+            "title": "Name",
+            "description": "The name of the website"
+          },
+          "url": {
+            "type": "string",
+            "minLength": 1,
+            "format": "uri",
+            "title": "Url",
+            "description": "The URL of the website"
+          }
+        },
+        "type": "object",
+        "required": [
+          "id",
+          "name",
+          "url"
+        ],
+        "title": "SearchResultWebsite"
+      },
+      "UpdateResponse": {
+        "properties": {
+          "id": {
+            "type": "string",
+            "title": "Id",
+            "description": "The ID of the website"
+          },
+          "name": {
+            "type": "string",
+            "title": "Name",
+            "description": "The name of the website"
+          },
+          "url": {
+            "type": "string",
+            "minLength": 1,
+            "format": "uri",
+            "title": "Url",
+            "description": "The URL of the website"
+          },
+          "affiliations": {
+            "items": {
+              "$ref": "#/components/schemas/Affiliation"
+            },
+            "type": "array",
+            "title": "Affiliations",
+            "description": "The affiliations of the website"
+          }
+        },
+        "type": "object",
+        "required": [
+          "id",
+          "name",
+          "url",
+          "affiliations"
+        ],
+        "title": "UpdateResponse",
+        "example": {
+          "affiliations": [
+            {
+              "campus": "\u4ea4\u5927\u76f8\u95dc",
+              "department": "\u884c\u653f\u55ae\u4f4d",
+              "office": "\u5716\u66f8\u9928"
+            }
+          ],
+          "id": "clrnc14dr000008l235gx4c6c",
+          "name": "\u4ea4\u901a\u5927\u5b78\u5716\u66f8\u9928",
+          "url": "https://www.lib.nctu.edu.tw/"
+        }
+      },
+      "UpdateWebsitePayload": {
+        "properties": {
+          "affiliations": {
+            "items": {
+              "$ref": "#/components/schemas/Affiliation"
+            },
+            "type": "array",
+            "title": "Affiliations",
+            "description": "The affiliations of the website",
+            "default": []
+          },
+          "name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Name",
+            "description": "The name of the website"
+          },
+          "url": {
+            "anyOf": [
+              {
+                "type": "string",
+                "minLength": 1,
+                "format": "uri"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Url",
+            "description": "The URL of the website"
+          }
+        },
+        "type": "object",
+        "title": "UpdateWebsitePayload",
+        "example": {
+          "affiliations": [
+            {
+              "campus": "\u4ea4\u5927\u76f8\u95dc",
+              "department": "\u884c\u653f\u55ae\u4f4d",
+              "office": "\u5716\u66f8\u9928"
+            }
+          ],
+          "name": "\u4ea4\u901a\u5927\u5b78\u5716\u66f8\u9928",
+          "url": "https://www.lib.nctu.edu.tw/"
+        }
+      },
+      "ValidationError": {
+        "properties": {
+          "loc": {
+            "items": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "integer"
+                }
+              ]
+            },
+            "type": "array",
+            "title": "Location"
+          },
+          "msg": {
+            "type": "string",
+            "title": "Message"
+          },
+          "type": {
+            "type": "string",
+            "title": "Error Type"
+          }
+        },
+        "type": "object",
+        "required": [
+          "loc",
+          "msg",
+          "type"
+        ],
+        "title": "ValidationError"
+      }
+    }
+  }
+}

--- a/pdm.lock
+++ b/pdm.lock
@@ -5,7 +5,7 @@
 groups = ["default", "dev"]
 strategy = ["cross_platform", "inherit_metadata"]
 lock_version = "4.4.1"
-content_hash = "sha256:a5bd46a2132247f7d5b6e1097ab05c274522f637273dd16b173f2cb02cb40a06"
+content_hash = "sha256:ee33d7874a40739fdeed6b7bd6742b7ce1bedd3e2973ca37dd21cdc749a9c9f4"
 
 [[package]]
 name = "annotated-types"
@@ -70,7 +70,7 @@ name = "click"
 version = "8.1.7"
 requires_python = ">=3.7"
 summary = "Composable command line interface toolkit"
-groups = ["default"]
+groups = ["default", "dev"]
 dependencies = [
     "colorama; platform_system == \"Windows\"",
 ]
@@ -84,7 +84,7 @@ name = "colorama"
 version = "0.4.6"
 requires_python = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,!=3.5.*,!=3.6.*,>=2.7"
 summary = "Cross-platform colored terminal text."
-groups = ["default"]
+groups = ["default", "dev"]
 marker = "sys_platform == \"win32\" or platform_system == \"Windows\""
 files = [
     {file = "colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,7 @@ license = { text = "MIT" }
 [project.optional-dependencies]
 dev = [
     "ruff>=0.1.14",
+    "click>=8.1.7",
 ]
 
 [tool.pdm]
@@ -29,7 +30,7 @@ distribution = false
 
 [tool.pdm.scripts]
 dev = "uvicorn app.app:app --reload --port 8000 --host 0.0.0.0 --log-config uvicorn_disable_logging.json"
-schema = { call = "app.openapi:main" } 
+"schema:gen" = { call = "app.openapi:dump_schema" } 
 format = "ruff format ."
 lint = "ruff check ."
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,7 @@ distribution = false
 
 [tool.pdm.scripts]
 dev = "uvicorn app.app:app --reload --port 8000 --host 0.0.0.0 --log-config uvicorn_disable_logging.json"
+schema = { call = "app.openapi:main" } 
 format = "ruff format ."
 lint = "ruff check ."
 


### PR DESCRIPTION
feat: dump openapi script

ignore: sql files and openapi.json

---

<details open="true"><summary>Generated summary (powered by <a href="https://app.graphite.dev">Graphite</a>)</summary>

> # Pull Request Description
> 
> ## TL;DR
> This pull request adds a new job called "openapi" to the "ci.yml" file. The job checks the OpenAPI schema and runs on the latest version of Ubuntu. It includes steps to checkout the repository, set up PDM (Python Development Master), install dependencies, add Python to the PATH, fabricate the environment, dump the OpenAPI schema, and check the schema.
> 
> ## What changed
> - Added a new job called "openapi" to the "ci.yml" file
> - The job checks the OpenAPI schema
> - The job runs on the latest version of Ubuntu
> - Steps added to the job include:
>   - Checkout the repository
>   - Set up PDM (Python Development Master)
>   - Install dependencies
>   - Add Python to the PATH
>   - Fabricate the environment
>   - Dump the OpenAPI schema
>   - Check the schema
> 
> ## How to test
> To test the changes made in this pull request, follow these steps:
> 1. Checkout the repository
> 2. Set up PDM (Python Development Master)
> 3. Install dependencies
> 4. Add Python to the PATH
> 5. Fabricate the environment
> 6. Dump the OpenAPI schema
> 7. Check the schema
> 
> ## Why make this change
> This change was made to add a new job that checks the OpenAPI schema. By running this job, we can ensure that the OpenAPI schema is valid and up to date. This helps in maintaining the quality and consistency of the API documentation.
</details>