### PR TITLE
fix: suppress type errors with updated pyright

### DIFF
--- a/app/core/config.py
+++ b/app/core/config.py
@@ -1,6 +1,7 @@
 from typing import Literal
 
-from pydantic import PostgresDsn, computed_field
+from pydantic import computed_field
+from pydantic_core import MultiHostUrl
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 from app.logger.custom import LogLevel
@@ -18,7 +19,7 @@ class Settings(BaseSettings):
 
     @computed_field
     def DATABASE_URL(self) -> str:
-        dsn = PostgresDsn.build(
+        dsn = MultiHostUrl.build(
             scheme="postgresql",
             username=self.DB_USER,
             password=self.DB_PASSWORD,
@@ -29,7 +30,7 @@ class Settings(BaseSettings):
 
         return str(dsn)
 
-    model_config: SettingsConfigDict = {
+    model_config: SettingsConfigDict = {  # type: ignore[reportIncompatibleVariableOverride]
         "env_file": ".env",
         "env_file_encoding": "utf-8",
         "extra": "ignore",

--- a/app/websites/details/db.py
+++ b/app/websites/details/db.py
@@ -20,7 +20,7 @@ class WebsiteInfo(BaseModel):
     website_url: str
     affiliationIds: list[AffiliationId]
 
-    model_config: ConfigDict = {
+    model_config: ConfigDict = {  # type: ignore[reportIncompatibleVariableOverride]
         "json_schema_extra": {
             "example": {
                 "website_name": "圖書館",

--- a/app/websites/schemas.py
+++ b/app/websites/schemas.py
@@ -16,7 +16,7 @@ class UpdateWebsitePayload(BaseModel):
     name: Optional[str] = Field(None, description="The name of the website")
     url: Optional[AnyUrl] = Field(None, description="The URL of the website")
 
-    model_config: ConfigDict = {
+    model_config: ConfigDict = {  # type: ignore[reportIncompatibleVariableOverride]
         "json_schema_extra": {
             "example": {
                 "affiliations": [
@@ -41,7 +41,7 @@ class UpdateResponse(BaseModel):
         ..., description="The affiliations of the website"
     )
 
-    model_config: ConfigDict = {
+    model_config: ConfigDict = {  # type: ignore[reportIncompatibleVariableOverride]
         "json_schema_extra": {
             "example": {
                 "id": "clrnc14dr000008l235gx4c6c",
@@ -85,7 +85,7 @@ class SearchResponse(BaseModel):
     result: list[SearchResultEntry] = Field(..., description="The search result")
     pagination: Pagination = Field(..., description="Pagination information")
 
-    model_config: ConfigDict = {
+    model_config: ConfigDict = {  # type: ignore[reportIncompatibleVariableOverride]
         "json_schema_extra": {
             "example": {
                 "result": [

--- a/app/websites/search/cursor.py
+++ b/app/websites/search/cursor.py
@@ -18,7 +18,7 @@ class ParseCursorError(BaseModel):
     type: ParseCursorErrorType
     msg: str
 
-    model_config: ConfigDict = {"extra": "allow"}
+    model_config: ConfigDict = {"extra": "allow"}  # type: ignore[reportIncompatibleVariableOverride]
 
 
 class SearchWebsiteCursor(BaseModel):

--- a/pdm.lock
+++ b/pdm.lock
@@ -5,7 +5,7 @@
 groups = ["default", "dev"]
 strategy = ["cross_platform", "inherit_metadata"]
 lock_version = "4.4.1"
-content_hash = "sha256:ee33d7874a40739fdeed6b7bd6742b7ce1bedd3e2973ca37dd21cdc749a9c9f4"
+content_hash = "sha256:8b11ca4659fb4ad2e95096c3b1b20438ae1ed94cee9754d295fdbe26e29c8ebc"
 
 [[package]]
 name = "annotated-types"
@@ -85,7 +85,7 @@ version = "0.4.6"
 requires_python = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,!=3.5.*,!=3.6.*,>=2.7"
 summary = "Cross-platform colored terminal text."
 groups = ["default", "dev"]
-marker = "sys_platform == \"win32\" or platform_system == \"Windows\""
+marker = "platform_system == \"Windows\" or sys_platform == \"win32\""
 files = [
     {file = "colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6"},
     {file = "colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44"},
@@ -144,6 +144,20 @@ groups = ["default"]
 files = [
     {file = "idna-3.6-py3-none-any.whl", hash = "sha256:c05567e9c24a6b9faaa835c4821bad0590fbb9d5779e7caa6e1cc4978e7eb24f"},
     {file = "idna-3.6.tar.gz", hash = "sha256:9ecdbbd083b06798ae1e86adcbfe8ab1479cf864e4ee30fe4e46a003d12491ca"},
+]
+
+[[package]]
+name = "nodeenv"
+version = "1.8.0"
+requires_python = ">=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,!=3.5.*,!=3.6.*"
+summary = "Node.js virtual environment builder"
+groups = ["dev"]
+dependencies = [
+    "setuptools",
+]
+files = [
+    {file = "nodeenv-1.8.0-py2.py3-none-any.whl", hash = "sha256:df865724bb3c3adc86b3876fa209771517b0cfe596beff01a92700e0e8be4cec"},
+    {file = "nodeenv-1.8.0.tar.gz", hash = "sha256:d51e0c37e64fbf47d017feac3145cdbb58836d7eee8c6f6d3b6880c5456227d2"},
 ]
 
 [[package]]
@@ -234,6 +248,20 @@ files = [
 ]
 
 [[package]]
+name = "pyright"
+version = "1.1.350"
+requires_python = ">=3.7"
+summary = "Command line wrapper for pyright"
+groups = ["dev"]
+dependencies = [
+    "nodeenv>=1.6.0",
+]
+files = [
+    {file = "pyright-1.1.350-py3-none-any.whl", hash = "sha256:f1dde6bcefd3c90aedbe9dd1c573e4c1ddbca8c74bf4fa664dd3b1a599ac9a66"},
+    {file = "pyright-1.1.350.tar.gz", hash = "sha256:a8ba676de3a3737ea4d8590604da548d4498cc5ee9ee00b1a403c6db987916c6"},
+]
+
+[[package]]
 name = "python-dotenv"
 version = "1.0.1"
 requires_python = ">=3.8"
@@ -296,6 +324,17 @@ files = [
     {file = "ruff-0.1.14-py3-none-win_amd64.whl", hash = "sha256:e3d241aa61f92b0805a7082bd89a9990826448e4d0398f0e2bc8f05c75c63d99"},
     {file = "ruff-0.1.14-py3-none-win_arm64.whl", hash = "sha256:269302b31ade4cde6cf6f9dd58ea593773a37ed3f7b97e793c8594b262466b67"},
     {file = "ruff-0.1.14.tar.gz", hash = "sha256:ad3f8088b2dfd884820289a06ab718cde7d38b94972212cc4ba90d5fbc9955f3"},
+]
+
+[[package]]
+name = "setuptools"
+version = "69.1.0"
+requires_python = ">=3.8"
+summary = "Easily download, build, install, upgrade, and uninstall Python packages"
+groups = ["dev"]
+files = [
+    {file = "setuptools-69.1.0-py3-none-any.whl", hash = "sha256:c054629b81b946d63a9c6e732bc8b2513a7c3ea645f11d0139a2191d735c60c6"},
+    {file = "setuptools-69.1.0.tar.gz", hash = "sha256:850894c4195f09c4ed30dba56213bf7c3f21d86ed6bdaafb5df5972593bfc401"},
 ]
 
 [[package]]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,7 @@ license = { text = "MIT" }
 dev = [
     "ruff>=0.1.14",
     "click>=8.1.7",
+    "pyright>=1.1.350",
 ]
 
 [tool.pdm]
@@ -33,6 +34,7 @@ dev = "uvicorn app.app:app --reload --port 8000 --host 0.0.0.0 --log-config uvic
 "schema:gen" = { call = "app.openapi:dump_schema" } 
 format = "ruff format ."
 lint = "ruff check ."
+typecheck = "pyright"
 
 [tool.ruff]
 extend-select = [


### PR DESCRIPTION
## Description

- Added `pyright` to dev dependencies for type checking in local environments
- Replaced `PostgresDsn.build` with `MultiHostUrl.build` to fit the new type checking mechanism of `pyright`
- Ignore all instance variable check for `pydantic` models' `model_config`